### PR TITLE
Allow to Config Auth JSON

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    revolut-connect (0.1.2)
+    revolut-connect (0.1.3)
       faraday (>= 1)
       faraday-retry (>= 1)
       jwt (>= 1)

--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Revolut.configure do |config|
   # Optional: Set the environment to be production or sandbox.
   # Default: sandbox
   config.environment = ENV["REVOLUT_ENVIRONMENT"]
+
+  # Optional: The JWT for an already exchanged token.
+  # Used to preload an existing auth token so that you don't have to exchange / renew it again.
+  config.auth_json = ENV["REVOLUT_AUTH_JSON"]
 end
 ```
 
@@ -228,6 +232,8 @@ deleted = Revolut::Payment.delete(transaction.id)
 ```
 
 ## Development
+
+You can use `bin/console` to access an interactive console. This will preload environment variables from a `.env` file.
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 

--- a/bin/console
+++ b/bin/console
@@ -1,9 +1,13 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "dotenv"
+Dotenv.load(".env")
+
 require "bundler/setup"
+
 Bundler.require(:default, :development)
-require "dotenv/load"
+require "pry"
 require "revolut"
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/lib/revolut.rb
+++ b/lib/revolut.rb
@@ -10,9 +10,6 @@ require_relative "revolut/client"
 require_relative "revolut/resources/resource"
 Dir[File.join(__dir__, "revolut", "resources", "*.rb")].each { |file| require file }
 
-# Load the authentication information from the environment variable REVOLUT_AUTH_JSON right away if possible.
-Revolut::Auth.load_from_env
-
 module Revolut
   class Error < StandardError; end
 
@@ -21,7 +18,7 @@ module Revolut
   class NotImplementedError < Error; end
 
   class Configuration
-    attr_accessor :request_timeout, :global_headers, :environment, :token_duration, :scope
+    attr_accessor :request_timeout, :global_headers, :environment, :token_duration, :scope, :auth_json
     attr_writer :client_id, :signing_key, :iss, :authorize_redirect_uri
     attr_reader :base_uri
 
@@ -38,6 +35,7 @@ module Revolut
       @iss = ENV.fetch("REVOLUT_ISS", "example.com")
       @authorize_redirect_uri = ENV["REVOLUT_AUTHORIZE_REDIRECT_URI"]
       @token_duration = ENV.fetch("REVOLUT_TOKEN_DURATION", DEFAULT_TOKEN_DURATION)
+      @auth_json = ENV["REVOLUT_AUTH_JSON"]
       @scope = ENV["REVOLUT_SCOPE"]
       @environment = ENV.fetch("REVOLUT_ENVIRONMENT", DEFAULT_ENVIRONMENT).to_sym
       @base_uri = (environment == :sandbox) ? "https://sandbox-b2b.revolut.com/api/1.0/" : "https://b2b.revolut.com/api/1.0/"
@@ -80,3 +78,6 @@ module Revolut
     end
   end
 end
+
+# Load the authentication information from the environment variable REVOLUT_AUTH_JSON right away if possible.
+Revolut::Auth.load_from_env

--- a/lib/revolut/resources/auth.rb
+++ b/lib/revolut/resources/auth.rb
@@ -105,17 +105,17 @@ module Revolut
         !@access_token.nil? && !expired?
       end
 
-      # Loads authentication information from environment variable REVOLUT_AUTH_JSON.
+      # Loads authentication information from the configuration auth_json.
       #
-      # If the access token is not already set and the environment variable REVOLUT_AUTH_JSON is present,
-      # this method loads the JSON data from the environment variable and calls the load method to set the authentication information.
+      # If the access token is not already set and auth_json config is present,
+      # this method loads the JSON data from the config variable and calls the load method to set the authentication information.
       #
       # Example:
       #   auth.load_from_env
       #
       # @return [void]
       def load_from_env
-        env_json = ENV["REVOLUT_AUTH_JSON"]
+        env_json = Revolut.config.auth_json
 
         return unless @access_token.nil? && env_json
 

--- a/lib/revolut/version.rb
+++ b/lib/revolut/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Revolut
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/revolut/resources/auth_spec.rb
+++ b/spec/revolut/resources/auth_spec.rb
@@ -78,9 +78,9 @@ RSpec.describe Revolut::Auth do
   end
 
   describe ".load_from_env" do
-    context "when REVOLUT_AUTH_JSON is set" do
+    context "when config is set" do
       before do
-        allow(ENV).to receive(:[]).with("REVOLUT_AUTH_JSON").and_return(access_token_data.to_json)
+        Revolut.config.auth_json = access_token_data.to_json
       end
 
       it "loads auth data from env" do
@@ -90,9 +90,9 @@ RSpec.describe Revolut::Auth do
       end
     end
 
-    context "when REVOLUT_AUTH_JSON is not set" do
+    context "when config is not set" do
       before do
-        allow(ENV).to receive(:[]).with("REVOLUT_AUTH_JSON").and_return(nil)
+        Revolut.config.auth_json = nil
       end
 
       it "does nothing" do

--- a/spec/revolut_spec.rb
+++ b/spec/revolut_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Revolut do
   it "has a version number" do
-    expect(Revolut::VERSION).to eq "0.1.2"
+    expect(Revolut::VERSION).to eq "0.1.3"
   end
 
   it "allows to configure" do


### PR DESCRIPTION
## Description

Allows to configure the auth json.

## Implementation

Leverages the same behavior as the rest of the configuration. 

We load it from the env, and if not present, we set it as nil.

## Checks

- [x] Have you followed the guidelines in our [Contributing section](https://github.com/moraki-finance/revolut-connect?tab=readme-ov-file#contributing)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?