### PR TITLE
Add Simulations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    revolut-connect (0.1.5)
+    revolut-connect (0.1.6)
       faraday (>= 2)
       faraday-retry (>= 2)
       jwt (>= 1)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ _:warning: For now this connector only supports the [Business API](https://devel
 - `Transaction`
 - `TransferReason`
 - `Webhook`
+- `Simulation`
 
 ## :construction: Roadmap
 
@@ -32,7 +33,6 @@ _:warning: For now this connector only supports the [Business API](https://devel
 - `ForeignExchange` resource
 - `PaymentDraft` resource
 - `PayoutLink` resource
-- `Simulation` resource
 - `TeamMember` resource
 - `Transfer` resource
 
@@ -245,6 +245,23 @@ transaction = Revolut::Payment.retrieve(payment.id)
 
 # Delete a payment transaction
 deleted = Revolut::Payment.delete(transaction.id)
+```
+
+#### Simulations
+
+<https://developer.revolut.com/docs/business/simulations>
+
+```rb
+# Update a transaction
+transaction = Revolut::Simulation.update_transaction("a6ea39d7-62c9-481c-8ba6-8a887a44c486", action: :complete)
+
+# Top up an account
+transaction = Revolut::Simulation.top_up_account("e042f1fe-f721-49cc-af82-db7a6c46944f",
+  amount: 100,
+  currency: "GBP",
+  reference: "Test Top-up",
+  state: "completed"
+)
 ```
 
 #### Webhooks

--- a/lib/revolut.rb
+++ b/lib/revolut.rb
@@ -19,6 +19,8 @@ module Revolut
 
   class SignatureVerificationError < Error; end
 
+  class UnsupportedOperationError < Error; end
+
   class Configuration
     attr_accessor :request_timeout, :global_headers, :environment, :token_duration, :scope, :auth_json, :api_version
     attr_writer :client_id, :signing_key, :iss, :authorize_redirect_uri

--- a/lib/revolut/resources/account.rb
+++ b/lib/revolut/resources/account.rb
@@ -7,6 +7,10 @@ module Revolut
       "accounts"
     end
 
+    # Retrieves the bank details for a specific account.
+    #
+    # @param id [String] The ID of the account.
+    # @return [Array<Revolut::BankAccount>] An array of bank account objects.
     def self.bank_details(id)
       response = http_client.get("/#{resources_name}/#{id}/bank-details")
 

--- a/lib/revolut/resources/resource.rb
+++ b/lib/revolut/resources/resource.rb
@@ -57,11 +57,11 @@ module Revolut
         @coerce_with ||= attrs
       end
 
-      protected
-
       def http_client
         @http_client ||= Revolut::Client.instance
       end
+
+      protected
 
       def resource_name
         resources_name
@@ -88,15 +88,9 @@ module Revolut
 
       def check_not_allowed
         method = caller(1..1).first.match(/`(\w+)'/)[1].to_sym
-        raise Revolut::Error, "`#{method}` is not allowed on this resource" if not_allowed_to.include?(method) || only.any? && !only.include?(method)
+        raise Revolut::UnsupportedOperationError, "`#{method}` operation is not allowed on this resource" if not_allowed_to.include?(method) || only.any? && !only.include?(method)
       end
     end
-
-    def to_json
-      @_raw.to_json
-    end
-
-    protected
 
     def initialize(attrs = {})
       @_raw = attrs
@@ -120,6 +114,10 @@ module Revolut
       end
 
       instance_variables.each { |iv| self.class.send(:attr_accessor, iv.to_s[1..].to_sym) }
+    end
+
+    def to_json
+      @_raw.to_json
     end
   end
 end

--- a/lib/revolut/resources/simulation.rb
+++ b/lib/revolut/resources/simulation.rb
@@ -1,0 +1,41 @@
+module Revolut
+  # Reference: https://developer.revolut.com/docs/business/counterparties
+  class Simulation < Resource
+    shallow
+
+    def self.resources_name
+      "sandbox"
+    end
+
+    # Updates a transaction in the sandbox environment.
+    #
+    # @param id [String] The ID of the transaction to update.
+    # @param action [Symbol] The action to perform on the transaction.
+    # @return [Revolut::Transaction] The updated transaction object.
+    # @raise [Revolut::UnsupportedOperationError] If the method is called in a non-sandbox environment or if the action is not supported.
+    def self.update_transaction(id, action:)
+      raise Revolut::UnsupportedOperationError, "#update_transaction is meant to be run only in sandbox environments" unless Revolut.sandbox?
+      raise Revolut::UnsupportedOperationError, "The action `#{action}` is not supported" unless %i[complete revert declined fail].include?(action)
+
+      response = http_client.post("/#{resources_name}/transactions/#{id}/#{action}")
+
+      Revolut::Transaction.new(response.body)
+    end
+
+    # Adds funds to the specified account in the sandbox environment.
+    #
+    # @param id [String] The ID of the account to top up.
+    # @param data [Hash] Additional data for the top-up request.
+    # @option data [Float] :amount The amount to top up the account by.
+    # @option data [String] :currency The currency of the top-up amount.
+    # @return [Revolut::Transaction] The transaction object representing the top-up.
+    # @raise [Revolut::UnsupportedOperationError] If the method is called outside of the sandbox environment.
+    def self.top_up_account(id, **data)
+      raise Revolut::UnsupportedOperationError, "#top_up_account is meant to be run only in sandbox environments" unless Revolut.sandbox?
+
+      response = http_client.post("/#{resources_name}/topup", data: data.merge(account_id: id))
+
+      Revolut::Transaction.new(response.body)
+    end
+  end
+end

--- a/lib/revolut/resources/webhook_event.rb
+++ b/lib/revolut/resources/webhook_event.rb
@@ -14,12 +14,12 @@ module Revolut
     def self.construct_from(request, signing_secret)
       json = request.body.read
       timestamp = request.headers["Revolut-Request-Timestamp"]
-      header_signature = request.headers["Revolut-Signature"]
+      header_signatures = request.headers["Revolut-Signature"].split(",")
       payload_to_sign = "v1.#{timestamp}.#{json}"
       digest = OpenSSL::Digest.new("sha256")
       signature_digest = "v1=" + OpenSSL::HMAC.hexdigest(digest, signing_secret, payload_to_sign)
 
-      if signature_digest == header_signature
+      if header_signatures.include? signature_digest
         new(JSON.parse(json))
       else
         raise Revolut::SignatureVerificationError, "Signature verification failed"

--- a/lib/revolut/version.rb
+++ b/lib/revolut/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Revolut
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/revolut/resources/resource_spec.rb
+++ b/spec/revolut/resources/resource_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Revolut::Resource do
     it "raises an exception when trying to execute a forbidden method" do
       expect {
         Revolut::Resource::NotAllowedToResource.update(1, name: "Test")
-      }.to raise_error(Revolut::Error, "`update` is not allowed on this resource")
+      }.to raise_error(Revolut::UnsupportedOperationError, "`update` operation is not allowed on this resource")
     end
 
     it "succeeds to execute an allowed method" do
@@ -171,7 +171,7 @@ RSpec.describe Revolut::Resource do
     it "raises an exception when trying to execute a forbidden method" do
       expect {
         Revolut::Resource::OnlyResource.retrieve(1)
-      }.to raise_error(Revolut::Error, "`retrieve` is not allowed on this resource")
+      }.to raise_error(Revolut::UnsupportedOperationError, "`retrieve` operation is not allowed on this resource")
     end
 
     it "succeeds to execute an allowed method" do
@@ -200,7 +200,7 @@ RSpec.describe Revolut::Resource do
     it "raises an exception when trying to execute a forbidden method" do
       expect {
         Revolut::Resource::ShallowResource.retrieve(1)
-      }.to raise_error(Revolut::Error, "`retrieve` is not allowed on this resource")
+      }.to raise_error(Revolut::UnsupportedOperationError, "`retrieve` operation is not allowed on this resource")
     end
   end
 

--- a/spec/revolut/resources/simulation_spec.rb
+++ b/spec/revolut/resources/simulation_spec.rb
@@ -1,0 +1,82 @@
+RSpec.describe Revolut::Simulation do
+  it "inherits from Resource" do
+    expect(described_class).to be < Revolut::Resource
+  end
+
+  it "#resources_name" do
+    expect(described_class.resources_name).to eq "sandbox"
+  end
+
+  it "is shallow" do
+    expect(described_class.send(:only)).to eq [:shallow]
+  end
+
+  describe "#update_transaction" do
+    it "updates a transaction when the environment is sandbox" do
+      Revolut.config.environment = :sandbox
+
+      allow(described_class.http_client).to receive(:post).with("/sandbox/transactions/1/complete").and_return(
+        OpenStruct.new(
+          body: {
+            "id" => "c6db947e-e9ce-41c2-b445-02e6eb741d21",
+            "state" => "completed"
+          }
+        )
+      )
+
+      transaction = described_class.update_transaction(1, action: :complete)
+
+      expect(transaction).to be_a(Revolut::Transaction)
+      expect(transaction).to have_attributes(
+        id: "c6db947e-e9ce-41c2-b445-02e6eb741d21",
+        state: "completed"
+      )
+    end
+
+    it "raises an error if the environment is production" do
+      Revolut.config.environment = :production
+
+      expect { described_class.update_transaction(1, action: :complete) }.to raise_error(Revolut::UnsupportedOperationError, "#update_transaction is meant to be run only in sandbox environments")
+    end
+
+    it "raises an error if the action is unsupported" do
+      Revolut.config.environment = :sandbox
+
+      expect { described_class.update_transaction(1, action: :unsupported) }.to raise_error(Revolut::UnsupportedOperationError, "The action `unsupported` is not supported")
+    end
+  end
+
+  describe "#top_up_account" do
+    let(:data) do
+      {
+        account_id: 1,
+        amount: 100,
+        currency: "USD",
+        reference: "Test Top-up",
+        state: "completed"
+      }
+    end
+
+    it "tops up an account" do
+      Revolut.config.environment = :sandbox
+
+      allow(described_class.http_client).to receive(:post).with("/sandbox/topup", data:).and_return(
+        OpenStruct.new(body: {id: "330953b8-b089-4cfd-9f03-e88173d64248", state: "completed"})
+      )
+
+      transaction = described_class.top_up_account(1, **data.except(:account_id))
+
+      expect(transaction).to be_a(Revolut::Transaction)
+      expect(transaction).to have_attributes(
+        id: "330953b8-b089-4cfd-9f03-e88173d64248",
+        state: "completed"
+      )
+    end
+
+    it "raises an error if the environment is production" do
+      Revolut.config.environment = :production
+
+      expect { described_class.top_up_account(1, **data.except(:account_id)) }.to raise_error(Revolut::UnsupportedOperationError, "#top_up_account is meant to be run only in sandbox environments")
+    end
+  end
+end

--- a/spec/revolut/resources/webhook_event_spec.rb
+++ b/spec/revolut/resources/webhook_event_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Revolut::WebhookEvent do
           body: StringIO.new('{"data":{"id":"645a7696-22f3-aa47-9c74-cbae0449cc46","new_state":"completed","old_state":"pending","request_id":"app_charges-9f5d5eb3-1e06-46c5-b1c0-3914763e0bcb"},"event":"TransactionStateChanged","timestamp":"2023-05-09T16:36:38.028960Z"}'),
           headers: {
             "Revolut-Request-Timestamp" => "1683650202360",
-            "Revolut-Signature" => "v1=bca326fb378d0da7f7c490ad584a8106bab9723d8d9cdd0d50b4c5b3be3837c0"
+            "Revolut-Signature" => "v1=bca326fb378d0da7f7c490ad584a8106bab9723d8d9cdd0d50b4c5b3be3837c0,v1=bca326fb378d0da7f7c490ad584a8106bab9723d8d9cdd0d50b4c5b3be3837c1"
           }
         )
       end

--- a/spec/revolut_spec.rb
+++ b/spec/revolut_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Revolut do
   it "has a version number" do
-    expect(Revolut::VERSION).to eq "0.1.5"
+    expect(Revolut::VERSION).to eq "0.1.6"
   end
 
   it "allows to configure" do


### PR DESCRIPTION
## Description

Adds the simulation resource that allows topups and changing transaction states.

## Implementation

Follows the same architecture as for the rest of the resources. The simulation resource is a shallow resource that only has 2 methods available: `top_up_account` and `update_transaction`

## Checks

- [x] Have you followed the guidelines in our [Contributing section](https://github.com/moraki-finance/revolut-connect?tab=readme-ov-file#contributing)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?