### PR TITLE
[Business Api] add ForeignExchange resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _:warning: For now this connector only supports the [Business API](https://devel
 
 - `Account`
 - `Counterparty`
+- `ForeignExchange`
 - `Payment`
 - `Transaction`
 - `TransferReason`
@@ -30,7 +31,6 @@ _:warning: For now this connector only supports the [Business API](https://devel
 ### Business API
 
 - `Card` resource
-- `ForeignExchange` resource
 - `PaymentDraft` resource
 - `PayoutLink` resource
 - `TeamMember` resource
@@ -101,7 +101,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
     And then, when you need to load the auth again:
 
     ```rb
-    Revolut::Auth.load(JSON.prase(auth_to_persist))
+    Revolut::Auth.load(JSON.parse(auth_to_persist))
     ```
 
     You can also store this json in an environment variable and the gem will auto load it:
@@ -149,8 +149,8 @@ Revolut.configure do |config|
   # Useful for observability tools like Helicone: https://www.helicone.ai/
   # Default: {}
   config.global_headers = {
-    "Helicone-Auth": "Bearer {HELICONE_API_KEY}"
-    "helicone-stream-force-format" => "true",
+    "Helicone-Auth": "Bearer {HELICONE_API_KEY}",
+    "helicone-stream-force-format" => "true"
   }
 
   # Optional: Set the environment to be production or sandbox.
@@ -216,6 +216,35 @@ retrieved_counterparty = Revolut::Counterparty.retrieve(created_counterparty.id)
 
 # Delete a counterparty
 deleted = Revolut::Counterparty.delete(retrieved_counterparty.id)
+```
+
+#### ForeignExchange
+
+<https://developer.revolut.com/docs/business/foreign-exchange>
+
+```rb
+# Exchange currencies
+exchange = Revolut::ForeignExchange.exchange(
+  request_id: "49c6a48b-6b58-40a0-b974-0b8c4888c8a9", # The ID of the request, provided by you. It helps you identify the transaction in your system.
+  from: {
+    account_id: "8fe12333-5b27-4ad5-896c-38a25673fcc8",
+    currency: "USD"
+  },
+  to: {
+    account_id: "b4a3bcd2-c1dd-47cc-ac50-40cdb5856d42",
+    currency: "GBP",
+    amount: 10
+  },
+ reference: "exchange"
+)
+
+
+# Retrieve information on exchange rates between currencies
+rate = Revolut::ForeignExchange.rate(
+  from: "EUR",
+  to: "USD",
+  amount: 100
+)
 ```
 
 #### Payments

--- a/lib/revolut/resources/foreign_exchange.rb
+++ b/lib/revolut/resources/foreign_exchange.rb
@@ -1,0 +1,28 @@
+require "forwardable"
+
+module Revolut
+  class ForeignExchange < Resource
+    shallow
+
+    class << self
+      extend Forwardable
+
+      def resource_name
+        "exchange"
+      end
+
+      def exchange(**attrs)
+        response = http_client.post("/#{resource_name}", data: attrs)
+
+        new(response.body)
+      end
+
+      # Delegate rate to the rate resource
+      def_delegators :rate_resource, :rate
+
+      def rate_resource
+        Revolut::Rate
+      end
+    end
+  end
+end

--- a/lib/revolut/resources/rate.rb
+++ b/lib/revolut/resources/rate.rb
@@ -1,0 +1,15 @@
+module Revolut
+  class Rate < Resource
+    shallow
+
+    def self.resource_name
+      "rate"
+    end
+
+    def self.rate(**)
+      response = http_client.get("/#{resource_name}", **)
+
+      new(response.body)
+    end
+  end
+end

--- a/spec/revolut/resources/foreign_exchange.rb
+++ b/spec/revolut/resources/foreign_exchange.rb
@@ -1,0 +1,49 @@
+RSpec.describe Revolut::ForeignExchange do
+  it "inherits from Resource" do
+    expect(described_class).to be < Revolut::Resource
+  end
+
+  it "#resource_name" do
+    expect(described_class.send(:resource_name)).to eq "exchange"
+  end
+
+  it "only" do
+    expect(described_class.send(:only)).to eq [:shallow]
+  end
+
+  it "#rate_resource" do
+    expect(described_class.rate_resource).to eq(Revolut::Rate)
+  end
+
+  it "#def_delegators" do
+    allow(Revolut::Rate).to receive(:rate).and_return("rate")
+
+    expect(described_class.rate).to eq("rate")
+  end
+
+  it "returns a ForeignExchange" do
+    body = {
+      request_id: "49c6a48b-6b58-40a0-b974-0b8c4888c8a7",
+      from: {
+        account_id: "8fe12333-5b27-4ad5-896c-38a25673fcc8",
+        currency: "USD"
+      },
+      to: {
+        account_id: "b4a3bcd2-c1dd-47cc-ac50-40cdb5856d42",
+        currency: "GBP",
+        amount: 10
+      },
+     reference: "exchange"
+    }
+
+    allow(described_class.http_client)
+      .to receive(:post)
+      .with("/exchange", data: body)
+      .and_return(OpenStruct.new(body: {state: "completed"}))
+
+    exchange = described_class.exchange(**body)
+
+    expect(exchange).to be_a(Revolut::ForeignExchange)
+    expect(exchange).to have_attributes(state: "completed")
+  end
+end

--- a/spec/revolut/resources/foreign_exchange.rb
+++ b/spec/revolut/resources/foreign_exchange.rb
@@ -33,7 +33,7 @@ RSpec.describe Revolut::ForeignExchange do
         currency: "GBP",
         amount: 10
       },
-     reference: "exchange"
+      reference: "exchange"
     }
 
     allow(described_class.http_client)

--- a/spec/revolut/resources/rate_spec.rb
+++ b/spec/revolut/resources/rate_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Revolut::Rate do
+  it "inherits from Resource" do
+    expect(described_class).to be < Revolut::Resource
+  end
+
+  it "#resource_name" do
+    expect(described_class.resource_name).to eq "rate"
+  end
+
+  it "is shallow" do
+    expect(described_class.send(:only)).to eq [:shallow]
+  end
+
+  it "returns a Rate" do
+    params = {from: "EUR", to: "USD", amount: 100}
+
+    allow(described_class.http_client)
+      .to receive(:get)
+      .with("/rate", params)
+      .and_return(OpenStruct.new(body: {rate: 1.1}))
+
+    rate = described_class.rate(**params)
+
+    expect(rate).to be_a(Revolut::Rate)
+    expect(rate).to have_attributes(rate: 1.1)
+  end
+end


### PR DESCRIPTION
## Description

Related Issue: https://github.com/moraki-finance/revolut-connect/issues/26

Add the `ForeignExchange` resource, to retrieve information on exchange rates between currencies and exchange currencies.

## Implementation
```ruby
Revolut::ForeignExchange.rate(
  from: "EUR",
  to: "USD",
  amount: 100
)

Revolut::ForeignExchange.exchange(
  request_id: "49c6a48b-6b58-40a0-b974-0b8c4888c8a7", # The ID of the request, provided by you. It helps you identify the transaction in your system.
  from: {
    account_id: "8fe12333-5b27-4ad5-896c-38a25673fcc8",
    currency: "USD"
  },
  to: {
    account_id: "b4a3bcd2-c1dd-47cc-ac50-40cdb5856d42",
    currency: "GBP",
    amount: 10
  },
 reference: "exchange"
)
```


## Screenshots

`Revolut::ForeignExchange.exchange()` call:
![Screenshot from 2024-07-25 19-18-22](https://github.com/user-attachments/assets/3a98ad61-ce2a-4151-9888-cbbc46a7081e)

`Revolut::ForeignExchange.rate()`  call:
![Screenshot from 2024-07-25 19-19-22](https://github.com/user-attachments/assets/1890c6aa-003a-4e6b-a2dc-b6e89a548242)

Testing check:
![image](https://github.com/user-attachments/assets/ba671a1c-7c9b-4bc8-9221-7e18d76d308e)

## Checks

- [x] Have you followed the guidelines in our [Contributing section](https://github.com/moraki-finance/revolut-connect?tab=readme-ov-file#contributing)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?