### PR TITLE
BusinessAPI: Add Transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,25 @@ transaction = Revolut::Simulation.top_up_account("e042f1fe-f721-49cc-af82-db7a6c
 )
 ```
 
+#### Transfers
+
+<https://developer.revolut.com/docs/business/transfers>
+
+```rb
+# Create a transfer
+Revolut::Transfer.create(
+  request_id: "129999", # The ID of the request, provided by you. It helps you identify the transaction in your system.
+  source_account_id: "b4a3bcd2-c1dd-47cc-ac50-40cdb5856d42",
+  target_account_id: "4cfb3825-7448-4825-baf8-7a17137c4634",
+  amount: 10,
+  currency: "GBP",
+  reference: "John's transfer"
+)
+
+# List transfer reasons
+transfer_reasons = Revolut::Transfer.list_reasons
+```
+
 #### Webhooks
 
 <https://developer.revolut.com/docs/business/webhooks-v-2>

--- a/lib/revolut/resources/transfer.rb
+++ b/lib/revolut/resources/transfer.rb
@@ -1,0 +1,22 @@
+require "forwardable"
+
+module Revolut
+  class Transfer < Resource
+    only :create
+
+    class << self
+      extend Forwardable
+
+      # Delegate list_reasons to the list method on TransferReason
+      def_delegator :transfer_reason, :list, :list_reasons
+
+      def resource_name
+        "transfer"
+      end
+
+      def transfer_reason
+        Revolut::TransferReason
+      end
+    end
+  end
+end

--- a/spec/revolut/resources/transfer_spec.rb
+++ b/spec/revolut/resources/transfer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Revolut::Transfer do
+  it "inherits from Resource" do
+    expect(described_class).to be < Revolut::Resource
+  end
+
+  it "#resource_name" do
+    expect(described_class.send(:resource_name)).to eq "transfer"
+  end
+
+  it "only" do
+    expect(described_class.send(:only)).to eq [:create]
+  end
+
+  it "#transfer_reasons" do
+    expect(described_class.transfer_reason).to eq(Revolut::TransferReason)
+  end
+
+  it "#def_delegator" do
+    allow(Revolut::TransferReason).to receive(:list).and_return("list")
+
+    expect(described_class.list_reasons).to eq("list")
+  end
+end


### PR DESCRIPTION
## Description

Add the Transfer resource, to move funds in the same currency between accounts of the same business. Related issue https://github.com/moraki-finance/revolut-connect/issues/29


## Implementation
```rb
# Create a transfer
Revolut::Transfer.create(
  request_id: "129999", # The ID of the request, provided by you. It helps you identify the transaction in your system.
  source_account_id: "b4a3bcd2-c1dd-47cc-ac50-40cdb5856d42",
  target_account_id: "4cfb3825-7448-4825-baf8-7a17137c4634",
  amount: 10,
  currency: "GBP",
  reference: "John's transfer"
)

# List transfer reasons
transfer_reasons = Revolut::Transfer.list_reasons
```

## Screenshots

Tests:
![image](https://github.com/user-attachments/assets/870eda6f-4f40-4b24-ae27-79652e9ceb89)

`Revolut::Transfer.create`:

![Screenshot from 2024-08-05 13-48-46](https://github.com/user-attachments/assets/32f9342c-7db6-42c0-89e3-954c4404b6a7)

`Revolut::Transfer.list_reasons`:

![Screenshot from 2024-08-05 13-51-10](https://github.com/user-attachments/assets/339edbe8-ccba-42b5-b61d-867bcb71db07)

## Checks

- [x] Have you followed the guidelines in our [Contributing section](https://github.com/moraki-finance/revolut-connect?tab=readme-ov-file#contributing)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?